### PR TITLE
Remove podIds and clarity refactor (extract method)

### DIFF
--- a/DeepMenu/Pod/MuPod.swift
+++ b/DeepMenu/Pod/MuPod.swift
@@ -2,8 +2,12 @@
 
 import SwiftUI
 
-class MuPod: Identifiable, ObservableObject {
+class MuPod: Identifiable, Equatable, ObservableObject {
     let id = MuIdentity.getId()
+
+    static func == (lhs: MuPod, rhs: MuPod) -> Bool {
+        return lhs.id == rhs.id
+    }
 
     @Published var spotlight = false // true when selected or under cursor
     var spotTime = TimeInterval(0)


### PR DESCRIPTION
I believe by making MuPod Equatable (same pattern as with MuHub) there is no need to track pod ids in a parallel collection in MuDock. I think this could be simplified even further if using a Set as the collection instead of an Array, assuming Swift has a Set implementation, but noot going that far for now.

Also extracted the sub pod building into its own method while I was trying to work out what it did, seemed ok to leave that change in.