### PR TITLE
MuIdentity tests

### DIFF
--- a/DeepMenu.xcodeproj/project.pbxproj
+++ b/DeepMenu.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		57A0A26127BED18A00B5598B /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = 57A0A26027BED18A00B5598B /* ViewInspector */; };
 		57A0A26327BED1E900B5598B /* MuSpokeViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0A26227BED1E900B5598B /* MuSpokeViewTests.swift */; };
 		57A0A26527BF15AA00B5598B /* config.yml in Resources */ = {isa = PBXBuildFile; fileRef = 57A0A26427BF15AA00B5598B /* config.yml */; };
+		57A0A26827C015F600B5598B /* MuIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0A26727C015F600B5598B /* MuIdentityTests.swift */; };
 		800064A327646D67004B4C63 /* MuLeaf.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800064A227646D67004B4C63 /* MuLeaf.swift */; };
 		8006196B27933375005960FF /* MuTouch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8006196A27933375005960FF /* MuTouch.swift */; };
 		800D4AE5272A2A6800E71519 /* MuSpoke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800D4AE4272A2A6800E71519 /* MuSpoke.swift */; };
@@ -74,6 +75,7 @@
 		57A0A23727BDAFAE00B5598B /* MuSpokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuSpokeTests.swift; sourceTree = "<group>"; };
 		57A0A26227BED1E900B5598B /* MuSpokeViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuSpokeViewTests.swift; sourceTree = "<group>"; };
 		57A0A26427BF15AA00B5598B /* config.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; name = config.yml; path = .circleci/config.yml; sourceTree = "<group>"; };
+		57A0A26727C015F600B5598B /* MuIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuIdentityTests.swift; sourceTree = "<group>"; };
 		800064A227646D67004B4C63 /* MuLeaf.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuLeaf.swift; sourceTree = "<group>"; };
 		800619692791D984005960FF /* scratch2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = scratch2.h; sourceTree = "<group>"; };
 		8006196A27933375005960FF /* MuTouch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuTouch.swift; sourceTree = "<group>"; };
@@ -159,6 +161,14 @@
 			path = Spoke;
 			sourceTree = "<group>";
 		};
+		57A0A26627C015D300B5598B /* Global */ = {
+			isa = PBXGroup;
+			children = (
+				57A0A26727C015F600B5598B /* MuIdentityTests.swift */,
+			);
+			path = Global;
+			sourceTree = "<group>";
+		};
 		800064A127646D44004B4C63 /* Leaf */ = {
 			isa = PBXGroup;
 			children = (
@@ -224,6 +234,7 @@
 		8014B7D92700DE3A00691126 /* DeepMenuTests */ = {
 			isa = PBXGroup;
 			children = (
+				57A0A26627C015D300B5598B /* Global */,
 				57A0A23627BDAF8400B5598B /* Spoke */,
 				8014B7DA2700DE3A00691126 /* DeepMenuTests.swift */,
 			);
@@ -543,6 +554,7 @@
 				57A0A26327BED1E900B5598B /* MuSpokeViewTests.swift in Sources */,
 				57A0A23827BDAFAE00B5598B /* MuSpokeTests.swift in Sources */,
 				8014B7DB2700DE3A00691126 /* DeepMenuTests.swift in Sources */,
+				57A0A26827C015F600B5598B /* MuIdentityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DeepMenuTests/Global/MuIdentityTests.swift
+++ b/DeepMenuTests/Global/MuIdentityTests.swift
@@ -35,10 +35,9 @@ class MuIdentityTests: XCTestCase {
             
             ids.sort()
             let firstId = ids[0]
-            XCTAssertEqual(firstId + 1, ids[1])
-            XCTAssertEqual(firstId + 2, ids[2])
-            XCTAssertEqual(firstId + 3, ids[3])
-            XCTAssertEqual(firstId + 4, ids[4])
+            for index in 1...(ids.count - 1) {
+                XCTAssertEqual(firstId + index, ids[index])
+            }
         }
         
         let _ = await parallelWork.result

--- a/DeepMenuTests/Global/MuIdentityTests.swift
+++ b/DeepMenuTests/Global/MuIdentityTests.swift
@@ -1,0 +1,51 @@
+//
+//  MuIdentityTests.swift
+//  DeepMenuTests
+//
+//  Created by Dav Yaginuma on 2/18/22.
+//
+
+import XCTest
+@testable import DeepMenu
+
+class MuIdentityTests: XCTestCase {
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func testIncrements() throws {
+        let id = MuIdentity.getId()
+        let nextId = MuIdentity.getId()
+        XCTAssertEqual(id + 1, nextId)
+    }
+    
+    func testIsThreadSafe() async throws {
+        let parallelWork = Task {
+            async let id1 = getIdAsynchronously()
+            async let id2 = getIdAsynchronously()
+            async let id3 = getIdAsynchronously()
+            async let id4 = getIdAsynchronously()
+            async let id5 = getIdAsynchronously()
+            
+            var ids = await [id1, id2, id3, id4, id5]
+            
+            XCTAssertEqual(5, ids.count)
+            
+            ids.sort()
+            let firstId = ids[0]
+            XCTAssertEqual(firstId + 1, ids[1])
+            XCTAssertEqual(firstId + 2, ids[2])
+            XCTAssertEqual(firstId + 3, ids[3])
+            XCTAssertEqual(firstId + 4, ids[4])
+        }
+        
+        let _ = await parallelWork.result
+
+        @Sendable
+        func getIdAsynchronously() async -> Int {
+            return MuIdentity.getId()
+        }
+    }
+}


### PR DESCRIPTION
I was curious id MuIdentity was thread safe, so I wrote a test to see if it would fail.

It didn't fail, but I'm still not sure if that is because my test isn't aggressive enough or if it is actually thread safe.

I wanted to spawn 100 concurrently executable threads and throw that at it, but the only way I could find to do this with async/await is using the `async let` assignment which requires individually declaring a var for each parallel task and then `await` all of them. I suspect that this is just an insurmountable limitation of the async/await paradigm and that to do a more aggressive test I would need to drop back to NSOperation or GCD or whatever.